### PR TITLE
Add dependabot check for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"


### PR DESCRIPTION
As some of the GitHub Actions may soon become deprectaed, I am adding a check to dependabot to keep our actions up to date.